### PR TITLE
Add environment variables as fallback strategy and update examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,20 @@
 # freighter
 
+Freighter is a command-line utility to move files to/from storage backends in a convenient and efficient manner.
 
-Frieghter is a utility to help move files to / from storage backends in a convenient and efficient manner.
- 
-Use cases may include:
+Use cases include:
 
-- Restoring some database backup files to a cloud compute instance
+- Restoring database backup files to a cloud compute instance
 - Uploading local files to Dropbox for safe storage
 - Downloading configuration files to a host from a VCS such as Github
 
-
-<h2>Currently Supported Backends</h2>
+## Currently Supported Storage Providers
 
 - Dropbox (v2 API)
 - Github (v3 API)
 
-
-<h2>Configuration File</h2>
-Freighter requires the presence of a .freighter file with any of the following supported extensions:
+## Storage Provider Configuration
+Freighter will firstly attempt to read a .freighter configuration file with any of the following supported extensions:
 json, toml, yaml, yml, properties, props, prop, hcl
 
 This configuration file currently supports two keys:
@@ -34,88 +31,122 @@ token: mydropboxtoken
 
 By default, Freighter assumes the presence of the configuration file in the /tmp directory; if it's located elsewhere it must be specified via the --config flag.
 
-For docker, this file can be mounted as a secret _(only compatible with swarm)_.
+For docker, this file can be mounted as a secret _(only compatible with swarm)_ or a regular volume file mapping _(both docker run and swarm compatible)_
 
-<h2>Restore Files</h2>
+If the configuration file is not present or is missing keys, Freighter will fall back to the following environment variables:
 
+- FREIGHTER_PROVIDER
+- FREIGHTER_TOKEN
 
-With Docker:
+## Restore Files
 
+With Docker Swarm and secret-mapped YML configuration file in non-default location:
 
-```sh
-docker service create -u [USER] -v [LOCAL_VOLUME_MAPPING]:/restore \
-  --secret source=.freighter.yml,target=/tmp/.freighter.yml \
+```shell
+docker service create -u [USER] \
+  --mount type=bind,source=[LOCAL_VOLUME_MAPPING],destination=/restore \
+  --secret freighter.yml \
+  opinari/freighter --config /run/secrets/freighter.yml restore REMOTE_FILE_PATH /restore/LOCAL_FILE_PATH 
+```
+
+With Docker and environment variables:
+
+```shell
+docker run -u [USER] \
+  -v [LOCAL_VOLUME_MAPPING]:/restore \
+  -e FREIGHTER_PROVIDER=[FREIGHTER_PROVIDER] \
+  -e FREIGHTER_TOKEN=[FREIGHTER_TOKEN] \
   opinari/freighter restore REMOTE_FILE_PATH /restore/LOCAL_FILE_PATH 
 ```
 
-With native binary
+With native binary and configuration file in default location:
 
-
-```sh
+```shell
 ./freighter restore FROM_REMOTE_PATH TO_LOCAL_PATH
 ```
 
+With native binary and environment variables:
 
-<h2>Backup Files</h2>
+```shell
+env FREIGHTER_PROVIDER=[FREIGHTER_PROVIDER] FREIGHTER_TOKEN=[FREIGHTER_TOKEN] ./freighter restore FROM_REMOTE_PATH TO_LOCAL_PATH
+```
 
+## Backup Files
 
-With Docker:
+With Docker Swarm and secret-mapped YML configuration file in default location:
 
-
-```sh
-docker service create -u [USER] -v [LOCAL_VOLUME_MAPPING]:/backup \
+```shell
+docker service create -u [USER] \
+  --mount type=bind,source=[LOCAL_VOLUME_MAPPING],destination=/backup \
   --secret source=.freighter.yml,target=/tmp/.freighter.yml \
   opinari/freighter backup /backup/LOCAL_FILE_PATH REMOTE_FILE_PATH 
 ```
 
-With native binary
+With Docker and environment variables:
 
-
-```sh
-./freighter backup FROM_LOCAL_PATH TO_REMOTE_PATH
+```shell
+docker run -u [USER] \
+  -v [LOCAL_VOLUME_MAPPING]:/backup \
+  -e FREIGHTER_PROVIDER=[FREIGHTER_PROVIDER] \
+  -e FREIGHTER_TOKEN=[FREIGHTER_TOKEN] \
+  opinari/freighter backup /backup/LOCAL_FILE_PATH REMOTE_FILE_PATH 
 ```
 
+With native binary and TOML configuration file in non-default location:
 
-<h2>Determine Age of File</h2>
-
-To determine the age of a file (in days):
-
-
-With Docker:
-
-
-```sh
-docker service create -u [USER] -v [LOCAL_VOLUME_MAPPING]:/age \
-  --secret source=.freighter.yml,target=/tmp/.freighter.yml \
-  opinari/freighter age REMOTE_FILE_PATH --ouput /age/OUTPUT_FILE_PATH 
+```shell
+./freighter --config /home/core/freighter.toml backup FROM_LOCAL_PATH TO_REMOTE_PATH
 ```
 
+With native binary and environment variables (Dropbox used as an example):
 
-With native binary
+```shell
+env FREIGHTER_PROVIDER=dropbox FREIGHTER_TOKEN=my_dropbox_access_token ./freighter backup FROM_LOCAL_PATH TO_REMOTE_PATH
+```
 
-```sh
+## Determine Age of File
+
+With Docker Swarm, environment variable for provider and secret configuration file for token in non-default location:
+
+```shell
+docker service create -u [USER] \
+  --env FREIGHTER_PROVIDER=[FREIGHTER_PROVIDER] \
+  --mount type=bind,source=[LOCAL_VOLUME_MAPPING],destination=/age \
+  --secret token.yml \
+  opinari/freighter --config /run/secrets/token.yml age REMOTE_FILE_PATH --ouput /age/OUTPUT_FILE_PATH 
+```
+
+With native binary and configuration file in default location writing to output file:
+
+```shell
 ./freighter age REMOTE_FILE_PATH --output /tmp/age
 ```
 
-<h2>Delete File(s)</h2>
+With native binary and environment variables writing to stdout:
 
+```shell
+env FREIGHTER_PROVIDER=[FREIGHTER_PROVIDER] FREIGHTER_TOKEN=[FREIGHTER_TOKEN] ./freighter age REMOTE_FILE_PATH
+```
 
-With Docker:
+## Delete Files
 
+With Docker Swarm and environment variables:
 
-```sh
+```shell
 docker service create -u [USER] \
-  --secret source=.freighter.yml,target=/tmp/.freighter.yml \
+  --env FREIGHTER_PROVIDER=[FREIGHTER_PROVIDER] \
+  --env FREIGHTER_TOKEN=[FREIGHTER_TOKEN] \
   opinari/freighter delete REMOTE_FILE_PATH
 ```
 
+With native binary and configuration file in default location, deleting a single file:
 
-With native binary
-
-```sh
-./freighter delete REMOTE_FILE_PATH [REMOTE_FILE_PATH...]
+```shell
+./freighter delete REMOTE_FILE_PATH
 ```
 
+With native binary and environment variables, deleting multiple files:
 
-
-<hr>
+```shell
+env FREIGHTER_PROVIDER=[FREIGHTER_PROVIDER] FREIGHTER_TOKEN=[FREIGHTER_TOKEN] ./freighter delete /remote/file1.tar.gz /remote/other/file2.tar.gz /remote/oldfile.tar.gz
+```

--- a/descriptor.json
+++ b/descriptor.json
@@ -7,10 +7,10 @@
     "licenses": ["MIT"]
   },
   "version": {
-    "name": "0.5.0",
-    "desc": "Freighter v0.5.0",
-    "released": "2017-07-05",
-    "vcs_tag": "0.5.0",
+    "name": "0.6.0",
+    "desc": "Freighter v0.6.0",
+    "released": "2017-07-06",
+    "vcs_tag": "0.6.0",
     "gpgSign": false
   },
   "files": [


### PR DESCRIPTION
Look up Freighter's storage provider type and token from environment
variables if there is no configuration file or it does not contain
the expected keys.

Update README with variety of examples:

- Docker swarm with secret-mapped configuration file
- Docker with environment variables
- Docker swarm with env variable for provider and secret for token
- Binary with configuration file in default and non-default locations
- Binary with environment variables

@daves125125 